### PR TITLE
Fix HQ detection logic

### DIFF
--- a/src/main/java/com/swiftly/swiftly/service/SwiftCodeService.java
+++ b/src/main/java/com/swiftly/swiftly/service/SwiftCodeService.java
@@ -47,10 +47,14 @@ public class SwiftCodeService {
     }
 
     public boolean isHeadquarterCode(String swiftCode) {
+        if (swiftCode == null) {
+            return false;
+        }
 
-        if (swiftCode.length() <= 8) {
+        if (swiftCode.length() == 8) {
             return true;
         }
+
         return swiftCode.length() == 11 && swiftCode.endsWith("XXX");
     }
 }

--- a/src/test/java/com/swiftly/swiftly/service/SwiftCodeServiceTest.java
+++ b/src/test/java/com/swiftly/swiftly/service/SwiftCodeServiceTest.java
@@ -14,5 +14,7 @@ class SwiftCodeServiceTest {
         Assertions.assertTrue(service.isHeadquarterCode("ABCDEF12"));
         Assertions.assertTrue(service.isHeadquarterCode("ABCDEF12XXX"));
         Assertions.assertFalse(service.isHeadquarterCode("ABCDEF12345"));
+        Assertions.assertFalse(service.isHeadquarterCode("SHORT"));
+        Assertions.assertFalse(service.isHeadquarterCode(null));
     }
 }


### PR DESCRIPTION
## Summary
- fix bug in SwiftCodeService.isHeadquarterCode so it only returns true for valid headquarter codes
- add extra tests for short and null values

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f6310ea0483238486866b9eac2209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for SWIFT code checks to handle null values and enforce stricter length requirements.
- **Tests**
  - Added test cases to ensure correct handling of null and short SWIFT code inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->