### PR TITLE
Implement retrieval and deletion endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ spring.jpa.show-sql=true
 |--------|----------|-------------|
 | GET    | `/` | Simple welcome endpoint. Returns "Witaj w aplikacji Swiftly!" |
 | POST   | `/v1/swift-codes/import` | Imports an Excel file. Requires form-data with key `file` |
-| GET    | `/v1/swift-codes/{swiftCode}` | Returns details for a single SWIFT code. Includes "branches" for HQ codes |
+| GET    | `/v1/swift-codes/{swiftCode}` | Returns details for a single SWIFT code (404 if not found) |
 | GET    | `/v1/swift-codes/country/{iso2}` | Returns all codes for the specified ISO2 country code |
 | POST   | `/v1/swift-codes` | Creates a new SWIFT code entry |
-| DELETE | `/v1/swift-codes/{swiftCode}` | Deletes the specified code |
+| DELETE | `/v1/swift-codes/{swiftCode}` | Deletes the specified code (404 if not found) |
 
 ### Examples
 

--- a/src/main/java/com/swiftly/swiftly/controller/SwiftCodeController.java
+++ b/src/main/java/com/swiftly/swiftly/controller/SwiftCodeController.java
@@ -27,6 +27,31 @@ public class SwiftCodeController {
         this.excelParserService = excelParserService;
     }
 
+    @GetMapping("/{swiftCode}")
+    public ResponseEntity<?> getSwiftCode(@PathVariable String swiftCode) {
+        SwiftCode code = swiftCodeService.getBySwiftCode(swiftCode);
+        if (code == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "SWIFT code not found: " + swiftCode));
+        }
+        return ResponseEntity.ok(code);
+    }
+
+    @GetMapping("/country/{iso2}")
+    public ResponseEntity<?> getSwiftCodesByCountry(@PathVariable String iso2) {
+        return ResponseEntity.ok(swiftCodeService.getAllForCountry(iso2));
+    }
+
+    @DeleteMapping("/{swiftCode}")
+    public ResponseEntity<?> deleteSwiftCode(@PathVariable String swiftCode) {
+        try {
+            swiftCodeService.deleteBySwiftCode(swiftCode);
+            return ResponseEntity.ok(Map.of("message", "Deleted"));
+        } catch (RuntimeException ex) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", ex.getMessage()));
+        }
+    }
     @PostMapping("/import")
     public ResponseEntity<?> importSwiftCodes(@RequestParam("file") MultipartFile file) {
         try (InputStream is = file.getInputStream()) {

--- a/src/test/java/com/swiftly/swiftly/controller/SwiftCodeControllerTest.java
+++ b/src/test/java/com/swiftly/swiftly/controller/SwiftCodeControllerTest.java
@@ -1,0 +1,50 @@
+package com.swiftly.swiftly.controller;
+
+import com.swiftly.swiftly.service.ExcelParserService;
+import com.swiftly.swiftly.service.SwiftCodeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SwiftCodeController.class)
+class SwiftCodeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SwiftCodeService swiftCodeService;
+
+    @MockBean
+    private ExcelParserService excelParserService;
+
+    @Test
+    void getSwiftCodeReturnsNotFound() throws Exception {
+        when(swiftCodeService.getBySwiftCode("UNKNOWN")).thenReturn(null);
+        mockMvc.perform(get("/v1/swift-codes/UNKNOWN"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getCodesByCountryReturnsOk() throws Exception {
+        when(swiftCodeService.getAllForCountry("PL")).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/v1/swift-codes/country/PL"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteSwiftCodeNotFound() throws Exception {
+        doThrow(new RuntimeException("SWIFT code not found: UNKNOWN"))
+                .when(swiftCodeService).deleteBySwiftCode("UNKNOWN");
+        mockMvc.perform(delete("/v1/swift-codes/UNKNOWN"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- add GET and DELETE endpoints to `SwiftCodeController`
- describe new endpoints in README
- add controller tests covering new behaviour

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844854f49008323b4e7e31d91226ee8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API endpoints to retrieve a SWIFT code by code, retrieve all SWIFT codes for a specific country, and delete a SWIFT code.

- **Documentation**
  - Updated API documentation to clarify error handling and response codes for specific endpoints.

- **Tests**
  - Introduced tests to verify correct responses for retrieving and deleting SWIFT codes, including handling of non-existent codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->