### PR TITLE
Configure test profile using H2

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,11 @@ spring.jpa.show-sql=true
 ### Unit Tests
 - `SwiftCodeServiceTest.java` verifies service methods (e.g., `isHeadquarterCode`)
 - Run with `mvn test`
+  (uses the `test` profile with an in-memory H2 database)
 
 ### Integration Tests
 - `SwiftlyApplicationTests.java` ensures the application context loads correctly and verifies repository CRUD operations
+- Tests run against H2, so PostgreSQL is **not** required for executing tests
 
 ## Common Issues & Solutions
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,16 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>

--- a/src/test/java/com/swiftly/swiftly/SwiftlyApplicationTests.java
+++ b/src/test/java/com/swiftly/swiftly/SwiftlyApplicationTests.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SwiftlyApplicationTests {
 
 	@Autowired

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true


### PR DESCRIPTION
## Summary
- configure Spring Boot tests to use a `test` profile
- add H2 dependency for tests
- document how to run tests with the in-memory database

## Testing
- `./mvnw -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68448550384c83239c85af84f489c875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify that all tests use an in-memory H2 database and do not require PostgreSQL.
- **Chores**
  - Added H2 as a test dependency for automated testing.
  - Introduced a dedicated test configuration file for the H2 database.
  - Configured test classes to use the "test" profile during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->