### PR TITLE
Handle missing Swift code with 404 status

### DIFF
--- a/src/main/java/com/swiftly/swiftly/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swiftly/swiftly/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.swiftly.swiftly.exception.ResourceNotFoundException;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,5 +27,12 @@ public class GlobalExceptionHandler {
         Map<String, String> error = new HashMap<>();
         error.put("error", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<?> handleResourceNotFound(ResourceNotFoundException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
 }

--- a/src/main/java/com/swiftly/swiftly/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/swiftly/swiftly/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.swiftly.swiftly.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/swiftly/swiftly/service/SwiftCodeService.java
+++ b/src/main/java/com/swiftly/swiftly/service/SwiftCodeService.java
@@ -2,6 +2,7 @@ package com.swiftly.swiftly.service;
 
 import com.swiftly.swiftly.model.SwiftCode;
 import com.swiftly.swiftly.repository.SwiftCodeRepository;
+import com.swiftly.swiftly.exception.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -42,7 +43,7 @@ public class SwiftCodeService {
         if (existing != null) {
             swiftCodeRepository.delete(existing);
         } else {
-            throw new RuntimeException("SWIFT code not found: " + swiftCode);
+            throw new ResourceNotFoundException("SWIFT code not found: " + swiftCode);
         }
     }
 


### PR DESCRIPTION
## Summary
- add custom `ResourceNotFoundException`
- make `SwiftCodeService.deleteBySwiftCode` throw `ResourceNotFoundException`
- handle the exception in `GlobalExceptionHandler` and return `404 Not Found`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68448550a4048323be0b80a72c267215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling for missing resources by introducing a specific "Resource Not Found" error message when a requested item does not exist.
- **Bug Fixes**
  - Users now receive a clear and consistent 404 error response when attempting to delete or access a non-existent SWIFT code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->