### PR TITLE
Fix test expecting ResourceNotFoundException

### DIFF
--- a/src/test/java/com/swiftly/swiftly/controller/SwiftCodeControllerTest.java
+++ b/src/test/java/com/swiftly/swiftly/controller/SwiftCodeControllerTest.java
@@ -2,6 +2,7 @@ package com.swiftly.swiftly.controller;
 
 import com.swiftly.swiftly.service.ExcelParserService;
 import com.swiftly.swiftly.service.SwiftCodeService;
+import com.swiftly.swiftly.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -42,7 +43,7 @@ class SwiftCodeControllerTest {
 
     @Test
     void deleteSwiftCodeNotFound() throws Exception {
-        doThrow(new RuntimeException("SWIFT code not found: UNKNOWN"))
+        doThrow(new ResourceNotFoundException("SWIFT code not found: UNKNOWN"))
                 .when(swiftCodeService).deleteBySwiftCode("UNKNOWN");
         mockMvc.perform(delete("/v1/swift-codes/UNKNOWN"))
                 .andExpect(status().isNotFound());


### PR DESCRIPTION
## Summary
- update `SwiftCodeControllerTest` to expect `ResourceNotFoundException`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684bc23e726c83238a476b51cdd48e21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test to expect a specific error type when deleting a non-existent SWIFT code, ensuring more accurate error handling verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->